### PR TITLE
Update this gem to be able to use the new Instagram graph API endpoints

### DIFF
--- a/lib/instagram_basic_display/auth.rb
+++ b/lib/instagram_basic_display/auth.rb
@@ -46,7 +46,7 @@ module InstagramBasicDisplay
     # @return [InstagramBasicDisplay::Response] a response object containing either the token or an error
     def short_lived_token(access_code:)
       response = Net::HTTP.post_form(
-        URI('https://api.instagram.com/oauth/access_token'),
+        URI(auth_url),
         client_id: configuration.client_id,
         client_secret: configuration.client_secret,
         grant_type: 'authorization_code',
@@ -97,5 +97,13 @@ module InstagramBasicDisplay
     private
 
     attr_reader :configuration
+
+    def auth_url
+      if configuration.version == 1
+        'https://api.instagram.com/oauth/access_token'
+      else
+        'https://graph.instagram.com/oauth/access_token'
+      end
+    end
   end
 end

--- a/lib/instagram_basic_display/client.rb
+++ b/lib/instagram_basic_display/client.rb
@@ -35,8 +35,9 @@ module InstagramBasicDisplay
     # authentication utilities provided.
     #
     # @return void
-    def initialize(auth_token: nil)
+    def initialize(auth_token: nil, version: 1)
       @auth_token = auth_token
+      @version = version
 
       @auth = Auth.new(configuration)
       @profile = Profile.new(configuration)
@@ -49,7 +50,7 @@ module InstagramBasicDisplay
     #
     # @return [InstagramBasicDisplay::Configuration]
     def configuration
-      @configuration ||= InstagramBasicDisplay::Configuration.new(auth_token: @auth_token)
+      @configuration ||= InstagramBasicDisplay::Configuration.new(auth_token: @auth_token, version: @version)
     end
 
     # Sets the gem's configuration

--- a/lib/instagram_basic_display/configuration.rb
+++ b/lib/instagram_basic_display/configuration.rb
@@ -18,14 +18,15 @@ module InstagramBasicDisplay
   # Holds configuration values that are used to make requests against the
   # Instagram API
   class Configuration
-    attr_accessor :client_id, :client_secret, :redirect_uri, :auth_token
+    attr_accessor :client_id, :client_secret, :redirect_uri, :auth_token, :version
 
     # Constructor method
     #
     # @param auth_token [String] token that will be used to make requests
     #
     # @return void
-    def initialize(auth_token: nil)
+    def initialize(auth_token: nil, version: 1)
+      @version = version
       @client_id = set_client_id
       @client_secret = set_client_secret
       @redirect_uri = set_redirect_uri
@@ -33,15 +34,27 @@ module InstagramBasicDisplay
     end
 
     def set_client_id
-      ENV.fetch('INSTAGRAM_CLIENT_ID')
+      if version == 1
+        ENV.fetch('INSTAGRAM_CLIENT_ID')
+      else
+        ENV.fetch('INSTAGRAM_CLIENT_ID_V2')
+      end
     end
 
     def set_client_secret
-      ENV.fetch('INSTAGRAM_CLIENT_SECRET')
+      if version == 1
+        ENV.fetch('INSTAGRAM_CLIENT_SECRET')
+      else
+        ENV.fetch('INSTAGRAM_CLIENT_SECRET_V2')
+      end
     end
 
     def set_redirect_uri
-      ENV.fetch('INSTAGRAM_REDIRECT_URI')
+      if version == 1
+        ENV.fetch('INSTAGRAM_REDIRECT_URI')
+      else
+        ENV.fetch('INSTAGRAM_REDIRECT_URI_V2')
+      end
     end
   end
 end

--- a/lib/instagram_basic_display/version.rb
+++ b/lib/instagram_basic_display/version.rb
@@ -15,6 +15,5 @@
 # limitations under the License.
 
 module InstagramBasicDisplay
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end
-

--- a/spec/fixtures/vcr_cassettes/short_lived_token_failed_v2.yml
+++ b/spec/fixtures/vcr_cassettes/short_lived_token_failed_v2.yml
@@ -1,0 +1,86 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://graph.instagram.com/oauth/access_token
+    body:
+      encoding: US-ASCII
+      string: client_id=mock_data&client_secret=mock_data&grant_type=mock_data&redirect_uri=mock_data
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.instagram.com
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Ig-Set-Password-Encryption-Web-Key-Id:
+      - mock_data
+      Ig-Set-Password-Encryption-Web-Pub-Key:
+      - mock_data
+      Vary:
+      - Accept-Language, Cookie
+      Content-Language:
+      - en
+      Date:
+      - Thu, 23 Jan 2020 09:46:40 GMT
+      - Thu, 23 Jan 2020 09:46:40 GMT
+      Strict-Transport-Security:
+      - max-age=31536000
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Security-Policy:
+      - 'report-uri https://www.instagram.com/security/csp_report/; default-src ''self''
+        https://www.instagram.com; img-src https: data: blob:; font-src https: data:;
+        media-src ''self'' blob: https://www.instagram.com https://*.cdninstagram.com
+        https://*.fbcdn.net; manifest-src ''self'' https://www.instagram.com; script-src
+        ''self'' https://instagram.com https://www.instagram.com https://*.www.instagram.com
+        https://*.cdninstagram.com wss://www.instagram.com https://*.facebook.com
+        https://*.fbcdn.net https://*.facebook.net ''unsafe-inline'' ''unsafe-eval''
+        blob:; style-src ''self'' https://*.www.instagram.com https://www.instagram.com
+        ''unsafe-inline''; connect-src ''self'' https://instagram.com https://www.instagram.com
+        https://*.www.instagram.com https://graph.instagram.com https://*.graph.instagram.com
+        https://*.cdninstagram.com https://api.instagram.com wss://www.instagram.com
+        wss://edge-chat.instagram.com https://*.facebook.com https://*.fbcdn.net https://*.facebook.net
+        chrome-extension://boadgeojelhgndaghljhdicfkmllpafd blob:; worker-src ''self''
+        blob: https://www.instagram.com; frame-src ''self'' https://instagram.com
+        https://www.instagram.com https://staticxx.facebook.com https://www.facebook.com
+        https://web.facebook.com https://connect.facebook.net https://m.facebook.com;
+        object-src ''none''; upgrade-insecure-requests'
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      X-Aed:
+      - '15'
+      Access-Control-Expose-Headers:
+      - X-IG-Set-WWW-Claim
+      X-Fb-Trip-Id:
+      - '780166575'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '92'
+    body:
+      encoding: UTF-8
+      string: '{"error_type": "OAuthException", "code": 400, "error_message": "Invalid
+        authorization code"}'
+    http_version:
+  recorded_at: Thu, 23 Jan 2020 09:46:33 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/short_lived_token_v2.yml
+++ b/spec/fixtures/vcr_cassettes/short_lived_token_v2.yml
@@ -1,0 +1,86 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://graph.instagram.com/oauth/access_token
+    body:
+      encoding: US-ASCII
+      string: client_id=mock_data&client_secret=mock_data&grant_type=authorization_code&redirect_uri=mock_data
+      headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.instagram.com
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Ig-Set-Password-Encryption-Web-Key-Id:
+      - mock_data
+      Ig-Set-Password-Encryption-Web-Pub-Key:
+      - mock_data
+      Vary:
+      - Accept-Language, Cookie, Accept-Encoding
+      Content-Language:
+      - en
+      Date:
+      - Thu, 23 Jan 2020 09:40:19 GMT
+      - Thu, 23 Jan 2020 09:40:19 GMT
+      Strict-Transport-Security:
+      - max-age=31536000
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Sat, 01 Jan 2000 00:00:00 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Security-Policy:
+      - 'report-uri https://www.instagram.com/security/csp_report/; default-src ''self''
+        https://www.instagram.com; img-src https: data: blob:; font-src https: data:;
+        media-src ''self'' blob: https://www.instagram.com https://*.cdninstagram.com
+        https://*.fbcdn.net; manifest-src ''self'' https://www.instagram.com; script-src
+        ''self'' https://instagram.com https://www.instagram.com https://*.www.instagram.com
+        https://*.cdninstagram.com wss://www.instagram.com https://*.facebook.com
+        https://*.fbcdn.net https://*.facebook.net ''unsafe-inline'' ''unsafe-eval''
+        blob:; style-src ''self'' https://*.www.instagram.com https://www.instagram.com
+        ''unsafe-inline''; connect-src ''self'' https://instagram.com https://www.instagram.com
+        https://*.www.instagram.com https://graph.instagram.com https://*.graph.instagram.com
+        https://*.cdninstagram.com https://api.instagram.com wss://www.instagram.com
+        wss://edge-chat.instagram.com https://*.facebook.com https://*.fbcdn.net https://*.facebook.net
+        chrome-extension://boadgeojelhgndaghljhdicfkmllpafd blob:; worker-src ''self''
+        blob: https://www.instagram.com; frame-src ''self'' https://instagram.com
+        https://www.instagram.com https://staticxx.facebook.com https://www.facebook.com
+        https://web.facebook.com https://connect.facebook.net https://m.facebook.com;
+        object-src ''none''; upgrade-insecure-requests'
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      X-Aed:
+      - '15'
+      Access-Control-Expose-Headers:
+      - X-IG-Set-WWW-Claim
+      X-Fb-Trip-Id:
+      - '1425083115'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '218'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token": "mock_short_lived_token",
+        "user_id": 1234567 }'
+    http_version:
+  recorded_at: Thu, 23 Jan 2020 09:40:12 GMT
+recorded_with: VCR 5.0.0

--- a/spec/instagram_basic_display/auth_spec.rb
+++ b/spec/instagram_basic_display/auth_spec.rb
@@ -44,6 +44,35 @@ RSpec.describe InstagramBasicDisplay::Auth do
         expect(response.error.code).to eq 400
       end
     end
+
+    context 'with version 2' do
+      let(:config) { InstagramBasicDisplay::Configuration.new(version: 2) }
+
+      subject { InstagramBasicDisplay::Auth.new(config) }
+
+      it 'exchanges an access code for a short lived token' do
+        VCR.use_cassette('short_lived_token_v2') do
+          response = subject.short_lived_token(access_code: 'asdf')
+  
+          expect(response).to be_a InstagramBasicDisplay::Response
+          expect(response.payload.access_token).to eq 'mock_short_lived_token'
+          expect(response.payload.user_id).to eq 1234567
+          expect(response.success?).to eq true
+        end
+      end
+  
+      it 'returns an error response when the request fails' do
+        VCR.use_cassette('short_lived_token_failed_v2') do
+          response = subject.short_lived_token(access_code: 'already_used_access_code')
+  
+          expect(response).to be_a InstagramBasicDisplay::Response
+          expect(response.success?).to eq false
+          expect(response.error.type).to eq 'OAuthException'
+          expect(response.error.message).to eq 'Invalid authorization code'
+          expect(response.error.code).to eq 400
+        end
+      end
+    end
   end
 
   describe '#long_lived_token' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,9 @@ require 'webmock'
 ENV['INSTAGRAM_CLIENT_ID'] = 'mock_client_id'
 ENV['INSTAGRAM_CLIENT_SECRET'] = 'mock_secret'
 ENV['INSTAGRAM_REDIRECT_URI'] = 'mock_redirect_uri'
+ENV['INSTAGRAM_CLIENT_ID_V2'] = 'mock_client_id'
+ENV['INSTAGRAM_CLIENT_SECRET_V2'] = 'mock_secret'
+ENV['INSTAGRAM_REDIRECT_URI_V2'] = 'mock_redirect_uri'
 
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'


### PR DESCRIPTION
[Tech plan](https://docs.google.com/document/d/1lcAzKIlOpsSPdNxbnWGAoXflbhPny-Ud61SmKbZR_7s/edit?tab=t.0)
[Linear](https://linear.app/kit/issue/BUIL-2337)

This adds a configuration option so we can use the Graph API vs. the old Basic Display API. According the migration guides, only the endpoints changed (See step 2, substep 2 on this [page](https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login/migration-guide)).